### PR TITLE
Add username/email login functionality

### DIFF
--- a/campaigns/authentication.py
+++ b/campaigns/authentication.py
@@ -1,0 +1,69 @@
+"""
+Custom authentication backend that allows users to login with either username or email.
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+from django.db.models import Q
+
+User = get_user_model()
+
+
+class EmailOrUsernameModelBackend(ModelBackend):
+    """
+    Custom authentication backend that allows users to authenticate 
+    using either their username or email address.
+    """
+    
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        """
+        Authenticate a user using either username or email.
+        
+        Args:
+            request: The HTTP request object
+            username: The username or email address provided
+            password: The password provided
+            **kwargs: Additional keyword arguments
+            
+        Returns:
+            User object if authentication succeeds, None otherwise
+        """
+        if username is None or password is None:
+            return None
+            
+        try:
+            # Try to find user by username or email
+            user = User.objects.get(
+                Q(username__iexact=username) | Q(email__iexact=username)
+            )
+            
+            # Check if the password is correct
+            if user.check_password(password):
+                return user
+                
+        except User.DoesNotExist:
+            # Run the default password hasher once to reduce the timing
+            # difference between an existing and a non-existing user
+            User().set_password(password)
+            return None
+        except User.MultipleObjectsReturned:
+            # Handle case where multiple users have the same email
+            # This shouldn't happen in a well-designed system, but we handle it
+            return None
+            
+        return None
+    
+    def get_user(self, user_id):
+        """
+        Get a user by their ID.
+        
+        Args:
+            user_id: The user's primary key
+            
+        Returns:
+            User object if found, None otherwise
+        """
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/campaigns/forms.py
+++ b/campaigns/forms.py
@@ -69,9 +69,17 @@ class ChapterUploadForm(forms.Form):
 class StyledAuthenticationForm(AuthenticationForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        
+        # Update field labels and help text
+        self.fields['username'].label = 'Username or Email'
+        self.fields['username'].help_text = 'Enter your username or email address'
+        
+        # Update styling
         self.fields['username'].widget.attrs.update({
             'class': 'w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500',
+            'placeholder': 'Username or email address'
         })
         self.fields['password'].widget.attrs.update({
             'class': 'w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500',
+            'placeholder': 'Password'
         })

--- a/campaigns/templates/accounts/login.html
+++ b/campaigns/templates/accounts/login.html
@@ -19,10 +19,13 @@
     <form method="post" class="space-y-6">
       {% csrf_token %}
 
-      <!-- Username -->
+      <!-- Username or Email -->
       <div>
-        <label for="id_username" class="block text-sm font-medium text-gray-300 mb-1">Username</label>
+        <label for="id_username" class="block text-sm font-medium text-gray-300 mb-1">{{ form.username.label }}</label>
         {{ form.username|add_class:"w-full px-3 py-2 rounded-md bg-gray-700 text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500" }}
+        {% if form.username.help_text %}
+        <p class="text-gray-400 text-xs mt-1">{{ form.username.help_text }}</p>
+        {% endif %}
         {% if form.username.errors %}
         <p class="text-red-400 text-xs mt-1">{{ form.username.errors.0 }}</p>
         {% endif %}

--- a/dnd_companion/settings.py
+++ b/dnd_companion/settings.py
@@ -109,6 +109,12 @@ INSTALLED_APPS = [
     "campaigns",
 ]
 
+# Authentication backends
+AUTHENTICATION_BACKENDS = [
+    'campaigns.authentication.EmailOrUsernameModelBackend',
+    'django.contrib.auth.backends.ModelBackend',
+]
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",


### PR DESCRIPTION
- Create custom authentication backend supporting both username and email login
- Update authentication form with dual login support and improved UX
- Add case-insensitive matching for flexible user authentication
- Update login template with clearer labeling and help text
- Configure Django settings to use custom authentication backend
- Maintain backward compatibility with existing username-only login
- Add security measures to prevent timing attacks
- Provide better user experience with "Username or Email" field

Features:
- Users can login with either username or email address
- Case-insensitive authentication for both fields
- Clear UI indicating dual login options
- Helpful placeholder text and guidance
- Secure implementation with proper error handling
- Fallback to default Django authentication backend

🤖 Generated with [Claude Code](https://claude.ai/code)