### PR TITLE
Add markdown support to encounter and chapter components

### DIFF
--- a/campaigns/templates/base.html
+++ b/campaigns/templates/base.html
@@ -15,6 +15,99 @@
       body {
         font-family: "Inter", sans-serif;
       }
+      
+      /* Custom markdown prose styling for dark theme */
+      .prose-invert {
+        --tw-prose-body: #d1d5db;
+        --tw-prose-headings: #f9fafb;
+        --tw-prose-links: #60a5fa;
+        --tw-prose-bold: #f9fafb;
+        --tw-prose-counters: #9ca3af;
+        --tw-prose-bullets: #6b7280;
+        --tw-prose-hr: #374151;
+        --tw-prose-quotes: #d1d5db;
+        --tw-prose-quote-borders: #374151;
+        --tw-prose-captions: #9ca3af;
+        --tw-prose-code: #fbbf24;
+        --tw-prose-pre-code: #e5e7eb;
+        --tw-prose-pre-bg: #1f2937;
+        --tw-prose-th-borders: #4b5563;
+        --tw-prose-td-borders: #374151;
+      }
+      
+      .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {
+        color: var(--tw-prose-headings);
+        font-weight: 600;
+      }
+      
+      .prose p {
+        color: var(--tw-prose-body);
+        margin-bottom: 1rem;
+      }
+      
+      .prose ul, .prose ol {
+        color: var(--tw-prose-body);
+        margin-left: 1.5rem;
+      }
+      
+      .prose ul li {
+        list-style-type: disc;
+        margin-bottom: 0.5rem;
+      }
+      
+      .prose ol li {
+        list-style-type: decimal;
+        margin-bottom: 0.5rem;
+      }
+      
+      .prose strong {
+        color: var(--tw-prose-bold);
+        font-weight: 600;
+      }
+      
+      .prose em {
+        font-style: italic;
+      }
+      
+      .prose code {
+        color: var(--tw-prose-code);
+        background-color: #374151;
+        padding: 0.125rem 0.25rem;
+        border-radius: 0.25rem;
+        font-size: 0.875rem;
+      }
+      
+      .prose pre {
+        background-color: var(--tw-prose-pre-bg);
+        color: var(--tw-prose-pre-code);
+        padding: 1rem;
+        border-radius: 0.375rem;
+        overflow-x: auto;
+      }
+      
+      .prose blockquote {
+        border-left: 4px solid var(--tw-prose-quote-borders);
+        padding-left: 1rem;
+        margin-left: 0;
+        color: var(--tw-prose-quotes);
+        font-style: italic;
+      }
+      
+      .prose table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      
+      .prose th, .prose td {
+        border: 1px solid var(--tw-prose-td-borders);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      
+      .prose th {
+        background-color: #374151;
+        font-weight: 600;
+      }
     </style>
   </head>
   <body class="bg-gray-900 text-white min-h-screen px-4 py-6 sm:px-6">

--- a/campaigns/templates/chapters/components/_chapter_overview.html
+++ b/campaigns/templates/chapters/components/_chapter_overview.html
@@ -1,3 +1,5 @@
+{% load markdown_extras %}
+
 <div class="bg-gray-800 p-6 rounded-lg shadow">
   <div class="flex items-center justify-between mb-4">
     <div class="flex items-center gap-4">
@@ -30,29 +32,29 @@
   <div class="space-y-4 text-gray-300">
     {% if chapter.summary %}
     <div>
-      <h2 class="text-xl font-semibold text-white">Summary</h2>
-      <p>{{ chapter.summary }}</p>
+      <h2 class="text-xl font-semibold text-white mb-2">Summary</h2>
+      <div class="prose prose-invert prose-sm max-w-none">{{ chapter.summary|markdown }}</div>
     </div>
     {% endif %}
     
     {% if chapter.intro %}
     <div>
-      <h2 class="text-xl font-semibold text-white">Introduction</h2>
-      <p>{{ chapter.intro }}</p>
+      <h2 class="text-xl font-semibold text-white mb-2">Introduction</h2>
+      <div class="prose prose-invert prose-sm max-w-none">{{ chapter.intro|markdown }}</div>
     </div>
     {% endif %}
     
     {% if chapter.dm_notes %}
     <div>
-      <h2 class="text-xl font-semibold text-white">DM Notes</h2>
-      <p>{{ chapter.dm_notes }}</p>
+      <h2 class="text-xl font-semibold text-white mb-2">DM Notes</h2>
+      <div class="prose prose-invert prose-sm max-w-none">{{ chapter.dm_notes|markdown }}</div>
     </div>
     {% endif %}
     
     {% if chapter.conclusion %}
     <div>
-      <h2 class="text-xl font-semibold text-white">Conclusion</h2>
-      <p>{{ chapter.conclusion }}</p>
+      <h2 class="text-xl font-semibold text-white mb-2">Conclusion</h2>
+      <div class="prose prose-invert prose-sm max-w-none">{{ chapter.conclusion|markdown }}</div>
     </div>
     {% endif %}
   </div>

--- a/campaigns/templates/encounters/components/_encounter_list_with_notes.html
+++ b/campaigns/templates/encounters/components/_encounter_list_with_notes.html
@@ -1,3 +1,5 @@
+{% load markdown_extras %}
+
 <div class="bg-gray-800 rounded-lg shadow">
   <div class="border-b border-gray-700 px-6 py-4 flex justify-between items-center">
     <h2 class="text-2xl font-semibold text-white">Encounters & Notes</h2>
@@ -45,10 +47,22 @@
           </div>
           {% endif %}
           
-          <p><strong>Summary:</strong> {{ enc.summary }}</p>
-          {% if enc.setup %}<p><strong>Setup:</strong> {{ enc.setup }}</p>{% endif %}
-          {% if enc.read_aloud %}<p><strong>Read-Aloud:</strong> {{ enc.read_aloud }}</p>{% endif %}
-          {% if enc.dm_notes %}<p><strong>DM Notes:</strong> {{ enc.dm_notes }}</p>{% endif %}
+          <div class="prose prose-invert prose-sm max-w-none">
+            <div><strong>Summary:</strong></div>
+            <div class="ml-4 mb-3">{{ enc.summary|markdown }}</div>
+            {% if enc.setup %}
+            <div><strong>Setup:</strong></div>
+            <div class="ml-4 mb-3">{{ enc.setup|markdown }}</div>
+            {% endif %}
+            {% if enc.read_aloud %}
+            <div><strong>Read-Aloud:</strong></div>
+            <div class="ml-4 mb-3 p-3 bg-gray-600 rounded border-l-4 border-indigo-500">{{ enc.read_aloud|markdown }}</div>
+            {% endif %}
+            {% if enc.dm_notes %}
+            <div><strong>DM Notes:</strong></div>
+            <div class="ml-4 mb-3">{{ enc.dm_notes|markdown }}</div>
+            {% endif %}
+          </div>
           {% if enc.map_reference %}<p><strong>Map Ref:</strong> {{ enc.map_reference }}</p>{% endif %}
           
           {% if enc.tags %}

--- a/campaigns/templates/encounters/components/_notes_list.html
+++ b/campaigns/templates/encounters/components/_notes_list.html
@@ -1,3 +1,5 @@
+{% load markdown_extras %}
+
 <div id="notes-list-{{ enc.id }}" class="mt-4 border-t border-gray-600 pt-4">
   <!-- Notes Header -->
   <div class="flex items-center justify-between mb-4">
@@ -72,8 +74,8 @@
             </div>
           </div>
         </div>
-        <div class="text-gray-200 leading-relaxed">
-          {{ note.content|linebreaks }}
+        <div class="text-gray-200 leading-relaxed prose prose-invert prose-sm max-w-none">
+          {{ note.content|markdown }}
         </div>
         {% if note.summary %}
         <div class="mt-3 pt-3 border-t border-gray-700">
@@ -83,7 +85,7 @@
             </svg>
             <span class="text-sm font-medium text-green-400">AI Summary</span>
           </div>
-          <p class="text-gray-300 text-sm italic">{{ note.summary }}</p>
+          <div class="text-gray-300 text-sm italic prose prose-invert prose-sm max-w-none">{{ note.summary|markdown }}</div>
         </div>
         {% endif %}
       </div>


### PR DESCRIPTION
- Enable markdown rendering for encounter fields (summary, setup, read-aloud, DM notes)
- Add markdown support to chapter overview sections (summary, intro, DM notes, conclusion)
- Include markdown rendering for session notes and AI summaries
- Add custom dark theme CSS for proper markdown prose styling
- Style read-aloud sections with special indigo border and background
- Support for headers, lists, code blocks, tables, and blockquotes
- Enhance DM creative freedom with rich text formatting options

🤖 Generated with [Claude Code](https://claude.ai/code)