### PR TITLE
Fix encounter_edit URL in chapter update form using old pattern

### DIFF
--- a/campaigns/templates/chapters/chapter_update_form.html
+++ b/campaigns/templates/chapters/chapter_update_form.html
@@ -115,7 +115,7 @@
                 </h4>
                 {% if enc_form.instance.pk %}
                 <div class="flex gap-2">
-                  <a href="{% url 'campaigns:encounter_edit' enc_form.instance.pk %}" 
+                  <a href="{% url 'campaigns:encounter_edit' campaign_id=chapter.campaign.id chapter_id=chapter.id encounter_id=enc_form.instance.pk %}" 
                      class="text-xs bg-indigo-600 hover:bg-indigo-700 text-white px-2 py-1 rounded">
                     Edit Details
                   </a>


### PR DESCRIPTION
Fixed the chapter update form template that was still using the old flat URL pattern for encounter_edit with just the pk argument instead of the new hierarchical pattern requiring campaign_id, chapter_id, and encounter_id.

This resolves the NoReverseMatch error when editing chapters with existing encounters.

🤖 Generated with [Claude Code](https://claude.ai/code)