### PR TITLE
Fix encounter update error by removing map_image references

### DIFF
--- a/campaigns/views/encounters.py
+++ b/campaigns/views/encounters.py
@@ -87,25 +87,23 @@ class EncounterUpdateView(LoginRequiredMixin, UpdateView):
         logger.info(f"Processing encounter form submission - User: {self.request.user.id}, "
                    f"Encounter: {form.instance.id}, Title: {form.instance.title}")
         
-        # Check if map_image was uploaded
-        if 'map_image' in form.changed_data:
-            map_image = form.cleaned_data.get('map_image')
-            if map_image:
-                logger.info(f"New map image uploaded - Name: {map_image.name}, "
-                           f"Size: {map_image.size} bytes, Content type: {map_image.content_type}")
+        # Check if map_reference was changed
+        if 'map_reference' in form.changed_data:
+            map_reference = form.cleaned_data.get('map_reference')
+            if map_reference:
+                logger.info(f"Map reference updated: {map_reference}")
             else:
-                logger.info("Map image field was changed but no file provided")
+                logger.info("Map reference field was cleared")
         else:
-            logger.info("No map image changes detected")
+            logger.info("No map reference changes detected")
         
         try:
             result = super().form_valid(form)
             logger.info(f"Encounter saved successfully - ID: {form.instance.id}")
             
-            # Log final map_image details if it exists
-            if form.instance.map_image:
-                logger.info(f"Final map image details - Name: {form.instance.map_image.name}, "
-                           f"URL: {form.instance.map_image.url}")
+            # Log final map_reference details if it exists
+            if form.instance.map_reference:
+                logger.info(f"Final map reference: {form.instance.map_reference}")
             
             messages.success(self.request, f"Encounter '{form.instance.title}' updated successfully.")
             return result


### PR DESCRIPTION
Fixed AttributeError where encounter views were trying to access map_image field that was moved to Location model in migration 0025.

✅ Issue Fixed:
- Encounter model only has map_reference (CharField), not map_image (ImageField)
- Migration 0025 moved map_image from Encounter to Location model
- View code was still trying to access the non-existent map_image field

✅ Changes Made:
- Updated EncounterUpdateView.form_valid() method
- Replaced map_image references with map_reference
- Updated logging to track map_reference changes instead of map_image uploads
- Maintained all other form validation and error handling logic

Now encounter updates work properly without AttributeError crashes.

🤖 Generated with [Claude Code](https://claude.ai/code)