### PR TITLE
Add duplicate 'Add' buttons at end of encounters and notes lists

### DIFF
--- a/campaigns/templates/encounters/components/_encounter_list_with_notes.html
+++ b/campaigns/templates/encounters/components/_encounter_list_with_notes.html
@@ -177,7 +177,19 @@
       
       {% include "encounters/components/_notes_list.html" %}
     </div>
-    {% endfor %} {% else %}
+    {% endfor %} 
+    
+    <!-- Add Encounter Button at End of List -->
+    {% if encounters %}
+    <div class="text-center pt-6">
+      <a href="{% url 'campaigns:encounter_create' campaign_id=chapter.campaign.id chapter_id=chapter.id %}" 
+         class="bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-3 px-6 rounded-md text-sm transition duration-200 inline-flex items-center">
+        <i class="fas fa-plus mr-2"></i>Add Another Encounter
+      </a>
+    </div>
+    {% endif %}
+    
+    {% else %}
     <p class="text-gray-500">No encounters added yet.</p>
     {% endif %}
   </div>

--- a/campaigns/templates/encounters/components/_notes_list.html
+++ b/campaigns/templates/encounters/components/_notes_list.html
@@ -90,6 +90,25 @@
         {% endif %}
       </div>
       {% endfor %}
+      
+      <!-- Add Note Button at End of Notes List -->
+      {% if enc.session_notes.all %}
+      <div class="text-center pt-4">
+        <button
+          type="button"
+          hx-get="{% url 'campaigns:encounter_note_form' campaign_id=enc.chapter.campaign.id chapter_id=enc.chapter.id encounter_id=enc.id %}"
+          hx-target="#note-form-{{ enc.id }}"
+          hx-swap="innerHTML"
+          class="bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md shadow text-sm font-medium transition duration-200 inline-flex items-center"
+        >
+          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+          </svg>
+          Add Another Note
+        </button>
+      </div>
+      {% endif %}
+      
     {% else %}
       <div class="bg-gray-800 rounded-lg border border-gray-600 p-6 text-center">
         <svg class="mx-auto h-12 w-12 text-gray-500 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
Improve user experience by providing additional "Add Another Encounter" and "Add Another Note" buttons at the end of their respective lists, eliminating the need to scroll back to the top when working with longer lists.

- Add "Add Another Encounter" button at bottom of encounters list
- Add "Add Another Note" button at end of each encounter's notes list
- Both buttons only appear when lists contain existing items
- Maintain same functionality and styling as original buttons

🤖 Generated with [Claude Code](https://claude.ai/code)